### PR TITLE
Github Issues data filters

### DIFF
--- a/tests/github/github.test.js
+++ b/tests/github/github.test.js
@@ -150,8 +150,8 @@ describe('Test Github Integration', () => {
 
       expect(data).to.haveOwnProperty('issues');
       expect(issues).to.be.instanceOf(Array);
-      expect(issues[0]).to.haveOwnProperty('issue_url');
-      expect(issues[0].issue_url).to.be.equal('https://github.com/GSA/code-gov-api/issues/243');
+      expect(issues[0]).to.haveOwnProperty('url');
+      expect(issues[0].url).to.be.equal('https://github.com/GSA/code-gov-api/issues/243');
     });
     it('should return an error', async () => {
       await errorTests({


### PR DESCRIPTION
# Pull Request Template

## Description

When fetching issues from the Github API v3 Pull Requests are included. This is because for Github they are the "same". We have to filter these PRs out of the results we want to index.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested

- [x] Ran project's test suite
![image](https://user-images.githubusercontent.com/1918027/49476110-119fee00-f7e7-11e8-85ae-c9dffa97e2c0.png)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
